### PR TITLE
Corrige texto de instrução em index

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -200,7 +200,7 @@ export default function Index() {
                 />
               </div>
               <p>
-                Você pode definir um ID personalizado que aparececerá no link
+                Você pode definir um ID personalizado que aparecerá no link
                 da sua reunião.
               </p>
             </div>


### PR DESCRIPTION
## Summary
- fix typo in Portuguese instruction

## Testing
- `npm test` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_6846102aeca0832b8f22e80a3a1fe57b