### PR TITLE
Switch project colors to green

### DIFF
--- a/components/TimeRangeSlider.tsx
+++ b/components/TimeRangeSlider.tsx
@@ -50,7 +50,7 @@ export default function TimeRangeSlider(props: Props) {
         sx={{
           width: 336,
           height: 12,
-          color: '#f93636',
+          color: 'var(--mb-red)',
           '& .MuiSlider-thumb': {
             transition: 'none',
             height: 24,

--- a/styles/components/Calendar.module.scss
+++ b/styles/components/Calendar.module.scss
@@ -173,7 +173,7 @@
           }
 
           &.selected {
-            background: #f93636;
+            background: var(--mb-red);
           }
 
           &.faded {
@@ -188,7 +188,7 @@
                 background: var(--mid-gray);
 
                 &.selected {
-                  background: #2e7d32;
+                  background: var(--mb-red-hover);
                 }
               }
             }

--- a/styles/components/Calendar.module.scss
+++ b/styles/components/Calendar.module.scss
@@ -188,7 +188,7 @@
                 background: var(--mid-gray);
 
                 &.selected {
-                  background: #e01919;
+                  background: #2e7d32;
                 }
               }
             }

--- a/styles/components/DatesPicker.module.scss
+++ b/styles/components/DatesPicker.module.scss
@@ -79,7 +79,7 @@
         }
 
         &.selected {
-          background: #f93636;
+          background: var(--mb-red);
           color: var(--white);
         }
 

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -8,9 +8,9 @@
   --dark-white: #f0f0f0;
   --dim-white: #fafafa;
   --white: #fff;
-  --mb-red: #fa3737;
-  --mb-red-hover: #e83232;
-  --mb-red-active: #d62e2e;
+  --mb-red: #4caf50;
+  --mb-red-hover: #43a047;
+  --mb-red-active: #388e3c;
   --header: 96px;
 }
 
@@ -19,7 +19,7 @@
 
   &::selection {
     // color: var(--white);
-    background: #ffde69;
+    background: #c5e1a5;
   }
 }
 

--- a/util/sampleGradient.ts
+++ b/util/sampleGradient.ts
@@ -44,11 +44,11 @@ export function sampleGradient(shades: number) {
   // convert shade levels to colors
   return levels.map((x) => {
     if (x === 0) return '#E0E0E0'
-    if (x < 0.33) return lerpColor('#FFFBD6', '#FFDE69', progress(0, 0.33, x))
+    if (x < 0.33) return lerpColor('#E8F5E9', '#A5D6A7', progress(0, 0.33, x))
     if (x < 0.69)
-      return lerpColor('#FFDE69', '#FF9636', progress(0.33, 0.69, x))
+      return lerpColor('#A5D6A7', '#66BB6A', progress(0.33, 0.69, x))
     if (x < 0.82)
-      return lerpColor('#FF9636', '#FD7836', progress(0.69, 0.82, x))
-    return lerpColor('#FD7836', '#F93636', progress(0.82, 1, x))
+      return lerpColor('#66BB6A', '#43A047', progress(0.69, 0.82, x))
+    return lerpColor('#43A047', '#2E7D32', progress(0.82, 1, x))
   })
 }

--- a/util/styles.ts
+++ b/util/styles.ts
@@ -41,10 +41,10 @@ export const selectStyles = {
     background: state.isSelected
       ? 'var(--mb-red)'
       : state.isFocused
-      ? 'rgba(250, 56, 56, 0.2)'
+      ? 'rgba(76, 175, 80, 0.2)'
       : undefined,
     '&:active': {
-      background: 'rgba(250, 56, 56, 0.33)',
+      background: 'rgba(76, 175, 80, 0.33)',
     },
   }),
 }


### PR DESCRIPTION
## Summary
- update main color variables to green in `globals.scss`
- set a pale green highlight
- convert the availability gradient to green shades
- tweak react-select hover colors
- adjust calendar selection background

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684616d57e44832ba2b0a94fecc0d6d1